### PR TITLE
Document multi-stage builds

### DIFF
--- a/appuio-docker-builder.rst
+++ b/appuio-docker-builder.rst
@@ -121,6 +121,35 @@ Build Hook Example
 
 Here you'll find an example which uses a ``pre_build`` script to install Maven and uses it to download a ``.war`` file from an artefact repository: https://github.com/appuio/appuio-docker-builder-example. The ``Dockerfile`` picks up the ``.war`` file downloaded by the ``pre_build`` script and adds to the image with an ``ADD`` instruction. In a real project the ``ARTIFACT`` environment variable would be configure in a ``BuildConfig``. The example uses JBoss EAP, which is only available to you if you ordered it. However this approach also works with other base images.
 
+Multi-stage builds
+------------------
+
+**Note**:: As of September 2017 multi-stage builds are a beta feature included
+in the secure Docker builder.
+
+**Note**: Multi-stage builds can't be used when the source image for a build is
+overridden using `.spec.strategy.dockerStrategy.from.name
+<https://docs.openshift.com/container-platform/3.6/dev_guide/builds/build_strategies.html#docker-strategy-from>`__.
+
+Docker 17.05 and newer support `multi-stage builds
+<https://docs.docker.com/engine/userguide/eng-image/multistage-build/>__` where
+build stages can be partially reused for further stages. An example
+``Dockerfile`` from the Docker documentation:
+
+::
+
+  FROM golang:1.7.3 as builder
+  WORKDIR /go/src/github.com/alexellis/href-counter/
+  RUN go get -d -v golang.org/x/net/html
+  COPY app.go    .
+  RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
+
+  FROM alpine:latest
+  RUN apk --no-cache add ca-certificates
+  WORKDIR /root/
+  COPY --from=builder /go/src/github.com/alexellis/href-counter/app .
+  CMD ["./app"]
+
 Known Issues
 ------------
 


### PR DESCRIPTION
Docker 17.05 implemented multi-stage builds where the output of one
stage can be reused in further stages.