### PR TITLE
Fix broken reST syntax in Docker build description

### DIFF
--- a/appuio-docker-builder.rst
+++ b/appuio-docker-builder.rst
@@ -124,7 +124,7 @@ Here you'll find an example which uses a ``pre_build`` script to install Maven a
 Multi-stage builds
 ------------------
 
-**Note**:: As of September 2017 multi-stage builds are a beta feature included
+**Note**: As of September 2017 multi-stage builds are a beta feature included
 in the secure Docker builder.
 
 **Note**: Multi-stage builds can't be used when the source image for a build is

--- a/appuio-docker-builder.rst
+++ b/appuio-docker-builder.rst
@@ -132,7 +132,7 @@ overridden using `.spec.strategy.dockerStrategy.from.name
 <https://docs.openshift.com/container-platform/3.6/dev_guide/builds/build_strategies.html#docker-strategy-from>`__.
 
 Docker 17.05 and newer support `multi-stage builds
-<https://docs.docker.com/engine/userguide/eng-image/multistage-build/>__` where
+<https://docs.docker.com/engine/userguide/eng-image/multistage-build/>`__ where
 build stages can be partially reused for further stages. An example
 ``Dockerfile`` from the Docker documentation:
 


### PR DESCRIPTION
The recent documentation update adding multi-stage builds introduced
a minor reST syntax mistake, causing a link to not work.