### PR TITLE
Add Travis build config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python: 3.4
+install:
+    - pip3 install -r requirements.txt
+script:
+    - sphinx-build -b dummy -a -q -w warnings . _build
+    - |
+      if [ $(wc -c <warnings) -ne 0 ]; then
+          echo -e "\\e[31mERROR: failing build due to build warnings (see above)\\e[0m"
+          false
+      fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python: 3.4
 install:
     - pip3 install -r requirements.txt
 script:
-    - sphinx-build -b dummy -a -q -w warnings . _build
+    - sphinx-build -b html -a -q -w warnings . _build
     - |
       if [ $(wc -c <warnings) -ne 0 ]; then
           echo -e "\\e[31mERROR: failing build due to build warnings (see above)\\e[0m"

--- a/services/users/00_introduction.rst
+++ b/services/users/00_introduction.rst
@@ -1,7 +1,7 @@
 Introduction
 ============
 
-.. image:: users_architecture.PNG
+.. image:: users_architecture.png
 
 The **users** microservice is an `Elixir <http://elixir-lang.org>`_/`Phoenix <http://www.phoenixframework.org/>`_ application that manages user authentication. It runs as a backend service and is only accessible through the **API** as can be seen above.
 

--- a/services/webserver/10_container_building.rst
+++ b/services/webserver/10_container_building.rst
@@ -40,7 +40,7 @@ The most important customizations needed in order to run nginx on APPUiO are sho
     :linenos:
     :emphasize-lines: 7, 10, 17, 20-24, 29-30
 
-    ...
+    # ...
 
     # specifying the user is not necessary as we change user in the Dockerfile
     # user  nginx;
@@ -73,7 +73,7 @@ The most important customizations needed in order to run nginx on APPUiO are sho
             server_name _;
 
             location / {
-                ...
+                # ...
             }
         }
     }


### PR DESCRIPTION
Just added a Travis config for our Sphinx-based documentation. Figured you might also be interested and it's also in our interest that your documentation keeps building and renders properly.

Warnings fixed:

```
/home/user/src/appuio-docs/services/users/00_introduction.rst:5: WARNING: image file not readable: services/users/users_architecture.PNG
/home/user/src/appuio-docs/services/webserver/10_container_building.rst:38: WARNING: Could not lex literal_block as "nginx".
```