### PR TITLE
Bump OpenShift version to 3.7

### DIFF
--- a/appuio-docker-builder.rst
+++ b/appuio-docker-builder.rst
@@ -128,8 +128,8 @@ Multi-stage builds
 in the secure Docker builder.
 
 **Note**: Multi-stage builds can't be used when the source image for a build is
-overridden using `.spec.strategy.dockerStrategy.from.name
-<https://docs.openshift.com/container-platform/3.6/dev_guide/builds/build_strategies.html#docker-strategy-from>`__.
+overridden using :openshift:`.spec.strategy.dockerStrategy.from.name
+<dev_guide/builds/build_strategies.html#docker-strategy-from>`.
 
 Docker 17.05 and newer support `multi-stage builds
 <https://docs.docker.com/engine/userguide/eng-image/multistage-build/>`__ where

--- a/appuio-specifics-public.rst
+++ b/appuio-specifics-public.rst
@@ -9,7 +9,7 @@ Versions
 --------
 
 - Operating System: Red Hat Enterprise Linux (RHEL) 7
-- OpenShift Container Platform: 3.6
+- OpenShift Container Platform: 3.7
 - Docker: 1.12
 
 You can download matching clients directly from APPUiO: :doc:`getting-started`.

--- a/conf.py
+++ b/conf.py
@@ -225,5 +225,5 @@ texinfo_documents = [
 [extensions]
 todo_include_todos=True
 extlinks = {
-    'openshift': ('https://docs.openshift.com/container-platform/3.6/%s', None)
+    'openshift': ('https://docs.openshift.com/container-platform/3.7/%s', None)
 }


### PR DESCRIPTION
The APPUiO cluster was upgraded to OpenShift 3.7 in May 2018.