### PR TITLE
Fix dangling link by pointing to OpenShift 3.11 console walkthrough

### DIFF
--- a/getting-started.rst
+++ b/getting-started.rst
@@ -38,7 +38,7 @@ CLI <https://access.redhat.com/documentation/en/openshift-enterprise/version-3.2
 
 APPUiO Sample Applications
 --------------------------
-If you want to deploy your first "hello world" example, see OpenShift's `Developers: Web Console Walkthrough <https://docs.openshift.com/enterprise/3.11/getting_started/developers_console.html>`__. Or dive right into some sample applications for APPUiO in our `Application Tutorial section </en/latest/#app-tutorials>`__.
+If you want to deploy your first "hello world" example, see OpenShift's `Developers: Web Console Walkthrough <https://docs.openshift.com/container-platform/3.11/getting_started/developers_console.html>`__. Or dive right into some sample applications for APPUiO in our `Application Tutorial section </en/latest/#app-tutorials>`__.
 
 APPUiO - Techlab
 ----------------

--- a/getting-started.rst
+++ b/getting-started.rst
@@ -38,7 +38,7 @@ CLI <https://access.redhat.com/documentation/en/openshift-enterprise/version-3.2
 
 APPUiO Sample Applications
 --------------------------
-If you want to deploy your first "hello world" example, see OpenShift's `Developers: Web Console Walkthrough <https://docs.openshift.com/enterprise/latest/getting_started/developers_console.html>`__. Or dive right into some sample applications for APPUiO in our `Application Tutorial section </en/latest/#app-tutorials>`__.
+If you want to deploy your first "hello world" example, see OpenShift's `Developers: Web Console Walkthrough <https://docs.openshift.com/enterprise/3.11/getting_started/developers_console.html>`__. Or dive right into some sample applications for APPUiO in our `Application Tutorial section </en/latest/#app-tutorials>`__.
 
 APPUiO - Techlab
 ----------------


### PR DESCRIPTION
The target doesn't exist anymore on the current "latest" tree
(corresponding to OpenShift 4.1).  As long as most APPUiO
installations in the real world are based on OpenShift 3.11 or older,
it is better to link to that "old" version of the page than to a
non-existing page or even a variant of this documentation that may not
exist to what users actually see.

Fixes #51