### PR TITLE
Make "Custom Applications" tutorial article more prominent

### DIFF
--- a/app/customapplications.rst
+++ b/app/customapplications.rst
@@ -1,5 +1,21 @@
 Custom Applications
--------------------
+===================
 
-Check out the `OpenShift Creating New Applications Docs <https://docs.openshift.com/enterprise/3.2/dev_guide/new_app.html>`__ for other languages, frameworks and strategies.
+For application development we recommend to set up a complete CI/CD pipeline
+with linting, automated tests, automatic image builds and deployment, all
+from source code.
 
+Please visit the following sites for working demo setups we have prepared
+for your convenience:
+
+- https://gitlab.com/appuio
+- https://bitbucket.org/appuio
+- https://github.com/appuio
+
+OpenShift Developer Guide
+-------------------------
+
+Alternatively, you may consult the OpenShift Developer Guide on
+`Creating New Applications
+<https://docs.openshift.com/container-platform/3.11/dev_guide/application_lifecycle/new_app.html>`__,
+which covers several languages, frameworks and strategies.

--- a/index.rst
+++ b/index.rst
@@ -42,6 +42,7 @@ The get started with an example, have a look at the very detailed
    :maxdepth: 2
    :caption: Application Tutorials
 
+   app/customapplications
    app/phpsti
    app/phpdockerbuild
    app/php7apachesti
@@ -55,7 +56,6 @@ The get started with an example, have a look at the very detailed
    app/dockerimage
    app/htmlstaticcontent
    app/wildflybinarydeployment
-   app/customapplications
    app/nodejs6example
    app/mssqllinux
    app/moreopenshiftsamples


### PR DESCRIPTION
* Places the "Custom Applications" tutorial article on top of the navigation list
* Suggests CI/CD pipelines as best practice
* Points to VSHN and Puzzle demo setups
* Updates link to OpenShift developer guide

**Internal reference:** APPU-2544