### PR TITLE
Let's Encrypt: Brush up visual markup, fix typos, explain default domain

### DIFF
--- a/faq.rst
+++ b/faq.rst
@@ -72,8 +72,11 @@ available under your own custom domain, follow these steps:
 1. Edit the route and change the hostname to your desired hostname, e.g. ``www.myapp.ch``
 2. Point your DNS entry using a CNAME resource record type (important!) to ``cname.appuioapp.ch``
 
-Always create a route before pointing a DNS entry to APPUiO, otherwise
-someone else could create a matchting route and serve content under your domain.
+.. warning::
+
+   Always create a route `before` pointing a DNS entry to APPUiO, otherwise
+   someone else could create a matching route and serve content under your
+   domain.
 
 Note that you can't use CNAME records in the apex domain (example.com, e.g.
 without www in front of it). If you need to use the apex domain for your

--- a/letsencrypt-integration.rst
+++ b/letsencrypt-integration.rst
@@ -1,52 +1,68 @@
 Let's Encrypt Integration
 =========================
 
-`Let's Encrypt <https://letsencrypt.org/>`__ is a certificate authority that 
-provides free SSL/TLS certificates via an automated process.
-Their certificates are accepted by most of todays browsers.
+`Let's Encrypt`_ is a certificate authority that provides free SSL/TLS
+certificates via an automated process.  Their certificates are accepted by
+most of today's browsers.
 
-APPUiO provides integration with Let's Encrypt to automatically create, sign, 
+APPUiO provides integration with Let's Encrypt to automatically create, sign,
 install and renew certificates for your domains running on APPUiO.
 
 To create a certificate for one of your domains follow these steps:
 
-#. If you haven't already done so create a route for the fully qualified domain 
+#. If you haven't already done so create a route for the fully qualified domain
    name (FQDN), e.g. ``www.example.org``, your application should run under
 #. Add a CNAME record (important!) for the FQDN to the DNS of your domain
-   pointing to ``cname.appuioapp.ch``. 
-   E.g. in BIND: ``www  IN  CNAME  cname.appuioapp.ch.`` (the trailing dot 
+   pointing to ``cname.appuioapp.ch``.
+   E.g. in BIND: ``www  IN  CNAME  cname.appuioapp.ch.`` (the trailing dot
    is required)
 #. Annotate your route:
-   ``oc -n MYNAMESPACE annotate route ROUTE kubernetes.io/tls-acme=true``
 
-Creating certificates for the default domain ``appuioapp.ch`` is neither needed
-nor supported as APPUiO already has a wildcard certificate installed for
-``*.appuioapp.ch``.
-Without this wildcard certificate we would hit the
-`Let's Encrypt rate limits <https://letsencrypt.org/docs/rate-limits/>`__ on the
+   .. code-block:: console
+
+      oc -n MYNAMESPACE annotate route ROUTE kubernetes.io/tls-acme=true
+
+.. warning::
+
+   Always **create a route** `before` **pointing a DNS entry** to APPUiO and
+   always **remove the corresponding DNS entry** `before` **deleting a route**
+   for a domain of yours.  Otherwise someone else could potentially create a
+   route and a Let's Encrypt certificate for your domain.
+
+.. note::
+
+   #. APPUiO automatically renews certificates a few days before they expire.
+   #. Let's Encrypt can only create `domain validated certificates`_,
+      i.e. it's not possible to add an organization name to a Let's Encrypt
+      certificate.
+
+If you don't specify a ``host`` value in your `Route object`_ APPUiO will use
+its default domain ``appuioapp.ch`` for your convenience to create a working
+subdomain for your application.
+
+Creating certificates for this domain is neither needed nor supported as APPUiO
+already has a wildcard certificate installed for ``*.appuioapp.ch``.  Without
+this wildcard certificate we would hit the `Let's Encrypt rate limits`_ on the
 ``appuioapp.ch`` domain sooner or later.
-
-**Important:** Always create a route before pointing a DNS entry to APPUiO and
-always remove the corresponding DNS entry before deleting a route for a domain
-of yours.
-Otherwise someone else could potentially create a route and a Let's Encrypt
-certificate for your domain.
-
-Please note:
-
-#. APPUiO automatically renews certificates a few days before they expire
-#. Let's encrypt can only create
-   `domain validated certificates <https://en.wikipedia.org/wiki/Domain-validated_certificate>`__,
-   i.e. it's not possible to add an organization name to a Let's Encrypt
-   certificate.
 
 Implementation details
 ----------------------
 
-APPUiO uses the `OpenShift ACME controller <https://github.com/tnozicka/openshift-acme>`__
-to provide the Let's Encrypt integration. 
+APPUiO uses the `OpenShift ACME controller`_ to provide the Let's Encrypt
+integration.
 
 The certificates are stored in the target Route object in the corresponding
-project. If you require the certificate to be stored as a Secret as well, add the 
-``acme.openshift.io/secret-name`` annotation, e.g.
-``oc -n MYNAMESPACE annotate route ROUTE acme.openshift.io/secret-name=mysecretname``
+project.  If you require the certificate to be stored as a Secret, to mount it
+into your Pod for SSL Passthrough, add the ``acme.openshift.io/secret-name``
+annotation, e.g.
+
+.. code-block:: console
+
+   oc -n MYNAMESPACE annotate route ROUTE acme.openshift.io/secret-name=MYSECRETNAME
+
+
+.. _Let's Encrypt: https://letsencrypt.org/
+.. _Let's Encrypt rate limits: https://letsencrypt.org/docs/rate-limits/
+.. _domain validated certificates: https://en.wikipedia.org/wiki/Domain-validated_certificate
+.. _Route object: https://docs.openshift.com/container-platform/3.11/architecture/networking/routes.html#route-hostnames
+.. _OpenShift ACME controller: https://github.com/tnozicka/openshift-acme


### PR DESCRIPTION
- Fix two minor typos
- Replace inline links
- Use "Warning" and "Info" boxes for nicer reading
- Explain APPUiO's default domain used for unspecified hosts
- Hint on SSL Passthrough, the motivation to create an external Secret