### PR TITLE
Added note regarding Openshift UI

### DIFF
--- a/letsencrypt-integration.rst
+++ b/letsencrypt-integration.rst
@@ -11,7 +11,9 @@ install and renew certificates for your domains running on APPUiO.
 To create a certificate for one of your domains follow these steps:
 
 #. If you haven't already done so create a route for the fully qualified domain
-   name (FQDN), e.g. ``www.example.org``, your application should run under
+   name (FQDN), e.g. ``www.example.org``, your application should run under. If
+   using the web console, make sure you do *not* tick the "Secure Route" box
+   when creating the route.
 #. Add a CNAME record (important!) for the FQDN to the DNS of your domain
    pointing to ``cname.appuioapp.ch``.
    E.g. in BIND: ``www  IN  CNAME  cname.appuioapp.ch.`` (the trailing dot


### PR DESCRIPTION
The letsencrypt integration doesn't seem to succeed when a user checks
the "secure route" box in the web UI.

Adding a simple note in that sense since this particular checkbox bit me this morning.