### PR TITLE
Limit sphinx-autobuild<2020.9.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ WORKDIR /src
 ADD requirements.txt .
 RUN pip install -r requirements.txt
 
-CMD ["sphinx-autobuild", ".", "_build_html", "-r", ".git", "--host", "0.0.0.0"]
+CMD ["sphinx-autobuild", ".", "_build_html", "--re-ignore", ".git", "--host", "0.0.0.0"]
 
 # vim: ft=dockerfile


### PR DESCRIPTION
The Python package for autobuilding the documentation,
sphinx-autobuild, had a breaking change with the latest
version (2020.9.1 of 31-Aug-2020).